### PR TITLE
Support select2-blur event

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -266,8 +266,11 @@ angular.module("rt.select2", [])
                         });
                     });
 
-                    element.on("select2-blur", function(e) {
-                        if (controller.$touched) return;
+                    element.on("select2-blur", function() {
+                        if (controller.$touched)
+                        {
+                            return;
+                        }
 
                         scope.$apply(controller.$setTouched);
                     });

--- a/src/select2.js
+++ b/src/select2.js
@@ -265,6 +265,13 @@ angular.module("rt.select2", [])
                             }
                         });
                     });
+
+                    element.on("select2-blur", function(e) {
+                        if (controller.$touched) return;
+
+                        scope.$apply(controller.$setTouched);
+                    });
+
                     controller.$render();
                 });
             }

--- a/src/select2.js
+++ b/src/select2.js
@@ -266,7 +266,7 @@ angular.module("rt.select2", [])
                         });
                     });
 
-                    element.on("select2-blur", function() {
+                    element.on("select2-blur", function () {
                         if (controller.$touched)
                         {
                             return;


### PR DESCRIPTION
$touched property is not setted when the directive lost the focus. I'm using select2's specific event select2-blur to set property $touched.