### PR TITLE
Hide keyboard on Andriod4 and IOS9

### DIFF
--- a/src/select2.js
+++ b/src/select2.js
@@ -253,6 +253,27 @@ angular.module("rt.select2", [])
 
                 $timeout(function () {
                     element.select2(opts);
+
+
+                    element.on('select2-open', function(e) {
+
+                        var $search = $( '.select2-search' );
+                        var $input  = $search.find( 'input' );
+                        // prevent keyboard from popping up for Android
+                        $input.attr( 'readonly', 'readonly' );
+                        $input.attr( 'disabled', 'true' );
+                        // prevent keyboard from popping up of iOS
+                        $input.blur();
+
+                        $('.select2-search').click( function() {
+                            console.log('click');
+                            $input.removeAttr( 'readonly' );
+                            $input.removeAttr( 'disabled' );
+                            $input.focus();
+                        } );
+
+                    });
+
                     element.on("change", function (e) {
                         scope.$evalAsync(function () {
                             var val;


### PR DESCRIPTION
I was having trouble with hiding the keyboard on android or ios (tested on 9 only).
I was able to concoct this solution which at least hides the keyboard until you tab on the searchbox.

The only issue I still have is that when you just select something in the list, the keyboard will popup anyway.
But that is another issue.
Hope you are willing to review and merge.